### PR TITLE
Fix error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 		log.Fatal().Msg("Error there is no node in the cluster")
 	}
 
-	gcloud.GetProjectDetailsFromNode(*nodes.Items[0].Spec.ProviderID)
+	err = gcloud.GetProjectDetailsFromNode(*nodes.Items[0].Spec.ProviderID)
 
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error getting project details from node; are you running this in GKE?")


### PR DESCRIPTION
I was wondering about the log message `location ""` is not allowed. The problem was my unauthorized GCP service account but the error was ignored.