### PR TITLE
Fix prometheus annotation metrics port

### DIFF
--- a/helm/estafette-gke-node-pool-shifter/templates/deployment.yaml
+++ b/helm/estafette-gke-node-pool-shifter/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- end }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
+        prometheus.io/port: "9101"
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
The application listens 9101 port for scaping metrics but Prometheus annotations configured for scaping on port 9001